### PR TITLE
Turn on CI for all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"] 
-  pull_request:
     branches: ["main"]
+  pull_request:
+    branches: ["*"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Not just those against main. This is useful when reviews are behind and we need to stack PRs.