### PR TITLE
Fix pytest failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: leanprover/lean-action@v1
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -25,6 +23,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - uses: leanprover/lean-action@v1
 
       - name: Run tests
         run: lake exe tensorlib test

--- a/Main.lean
+++ b/Main.lean
@@ -42,9 +42,10 @@ def runTests (_ : Parsed) : IO UInt32 := do
   -- Just pytest for now, but add Lean tests here as well
   -- pytest will exit nonzero on it's own, so we don't need to check exit code
   IO.println "Running PyTest..."
-  let stdout <- IO.Process.run { cmd := "pytest" }
-  IO.println stdout
-  return 0
+  let output <- IO.Process.output { cmd := "pytest" }
+  IO.println s!"stdout: {output.stdout}"
+  IO.println s!"stderr: {output.stderr}"
+  return output.exitCode
 
 def runTestsCmd := `[Cli|
   "test" VIA runTests;

--- a/TensorLib/NumpyRepr.lean
+++ b/TensorLib/NumpyRepr.lean
@@ -836,7 +836,6 @@ private def headerSizeToBytes (n : Nat) : UInt8 × UInt8 :=
 private def next64 (n : Nat) : Nat := 64 - (n % 64)
 
 -- Can we do this with local mutation?
--- TODO: write the correct endian-annotation character. Currently assuming little-endian with '<'
 private def toByteArray! (repr : NumpyRepr) : ByteArray :=
   let a := ByteArray.empty.push 0x93
   let a := pushString a "NUMPY"
@@ -844,7 +843,7 @@ private def toByteArray! (repr : NumpyRepr) : ByteArray :=
   let a := (a.push 0).push 0 -- index 8, 9. We will clobber this with the header size in a moment
   if a.size != 10 then panic s!"Bad header size: {a.size}, should be 9" else
   let a := pushStrings a [
-    "{'descr': '<",
+    "{'descr': '",
     repr.header.descr.toString,
     "', 'fortran_order': ",
     boolString repr.header.fortranOrder,

--- a/Test/parse_test.py
+++ b/Test/parse_test.py
@@ -1,20 +1,20 @@
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as nps
 import numpy as np
 import os
-import subprocess 
+import subprocess
 import tempfile
 import typing
 
 top = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-tensorlib = top + '/bin/tensorlib' 
+tensorlib = top + '/bin/tensorlib'
 
 def call_lean(file : str) -> str:
     return subprocess.check_output(
        [tensorlib, 'parse-npy', '--write', file],
        stderr=subprocess.STDOUT
-       )    
+       )
 
 def round_trip(arr : np.ndarray) -> tuple[str, np.ndarray]:
     (_, f) = tempfile.mkstemp(suffix=".npy")
@@ -24,10 +24,11 @@ def round_trip(arr : np.ndarray) -> tuple[str, np.ndarray]:
 
 dim1 = st.integers(min_value=1, max_value=512)
 dim2 = st.integers(min_value=1, max_value=10_000)
-shape = st.tuples(dim1, dim2) 
+shape = st.tuples(dim1, dim2)
 @given(
     nps.arrays(dtype=np.float32, shape=shape),
 )
+@settings(deadline=None) # The very first call is flakey wrt timing, e.g. 2s vs 100ms. 
 def test_numpy_save_load(arr):
     print(tensorlib)
     print(arr.shape)


### PR DESCRIPTION
Not sure how this passed in the previous commit.

- Ensure Python is installed before running lake
- Remove the hard-coded little-endian '< in the dtype encoding