### PR TITLE
chore: Remove wrong index compatibility check

### DIFF
--- a/TensorLib/Index.lean
+++ b/TensorLib/Index.lean
@@ -388,9 +388,9 @@ def apply (indexTensors : List Tensor) (arr : Tensor) : Err Tensor := do
 24 25 26
 -/
 #guard
-  let ind0 := (Tensor.Element.ofList Tensor.Element.Int8Native [1, 2, 0, 0]).reshape! (Shape.mk [2, 2])
-  let ind1 := (Tensor.Element.ofList Tensor.Element.Int8Native [2, -2, 0, 1]).reshape! (Shape.mk [2, 2])
-  let ind2 := (Tensor.Element.ofList Tensor.Element.Int8Native [1, 1, -1, -1]).reshape! (Shape.mk [2, 2])
+  let ind0 := (Tensor.Element.ofList Int8 [1, 2, 0, 0]).reshape! (Shape.mk [2, 2])
+  let ind1 := (Tensor.Element.ofList Int8 [2, -2, 0, 1]).reshape! (Shape.mk [2, 2])
+  let ind2 := (Tensor.Element.ofList Int8 [1, 1, -1, -1]).reshape! (Shape.mk [2, 2])
   let typ := BV16
   let arr := (Tensor.Element.arange typ 27).reshape! (Shape.mk [3, 3, 3])
   let res := get! $ apply [ind0, ind1, ind2] arr
@@ -400,31 +400,33 @@ def apply (indexTensors : List Tensor) (arr : Tensor) : Err Tensor := do
 end Advanced
 
 section Test
+open Tensor
+open Tensor.Format.Tree
 
 #guard
   let tp := BV8
-  let tensor := Tensor.Element.arange tp 10
+  let tensor := Element.arange tp 10
   let tensor := tensor.reshape! $ Shape.mk [2, 5]
   let index := [.int 1]
   let res := get! $ applyWithCopy index tensor
   let tree := get! $ res.toTree tp
-  let tree' := Tensor.Format.Tree.root [5, 6, 7, 8, 9]
+  let tree' := .root [5, 6, 7, 8, 9]
   tree == tree'
 
 #guard
   let tp := BV8
-  let tensor := Tensor.Element.arange tp 10
+  let tensor := Element.arange tp 10
   let tensor := tensor.reshape! $ Shape.mk [2, 5]
   let index := [.int 1]
   -- Bug in #guard keeps me from using `let (arr, copied) := ...` here
   let ac := get! $ apply index tensor
   let arr := ac.fst
   let copied := ac.snd
-  let tree' := Tensor.Format.Tree.root [5, 6, 7, 8, 9]
+  let tree' := .root [5, 6, 7, 8, 9]
   !copied && (get! $ arr.toTree tp) == tree'
 
 #guard let tp := BV8
-      let tensor := Tensor.Element.arange tp 20
+      let tensor := Element.arange tp 20
       let tensor := tensor.reshape! $ Shape.mk [2, 2, 5]
       let index := [.int 1, .int 1, .int 4]
       -- Bug in #guard keeps me from using `let (arr, copied) := ...` here
@@ -432,7 +434,7 @@ section Test
       let arr := ac.fst
       let copied := ac.snd
       let tree := get! $ arr.toTree tp
-      let tree' := Tensor.Format.Tree.root [19]
+      let tree' := .root [19]
       !copied && tree == tree'
 
 -- Testing

--- a/TensorLib/Tensor.lean
+++ b/TensorLib/Tensor.lean
@@ -269,7 +269,7 @@ class Element (a : Type) where
 namespace Element
 
 -- An array-scalar is a box around a scalar with nil shape that can be used for array operations like broadcasting
-def arrayScalar [w : Element a] (x : a) : Tensor :=
+def arrayScalar (a : Type) [w : Element a] (x : a) : Tensor :=
   { dtype := w.dtype, shape := Shape.empty, data := w.toByteArray x}
 
 --! An array of the numbers from 0 to n-1
@@ -293,7 +293,7 @@ def setPosition [typ : Element a] (x : Tensor) (n : Nat) (v : a): Err Tensor :=
   let posn := n * itemsize
   .ok { x with data := bytes.copySlice 0 x.data posn itemsize true }
 
-def ofList (typ : Element a) (xs : List a) : Tensor := Id.run do
+def ofList (a : Type) [typ : Element a] (xs : List a) : Tensor := Id.run do
   let arr := Tensor.zeros typ.dtype (Shape.mk [xs.length])
   let mut data := arr.data
   let mut posn := 0
@@ -504,7 +504,7 @@ private def toNpy (arr : Tensor) : Npy.Ndarray :=
 
 section Test
 
-#guard str BV8 (Element.arrayScalar (5 : BV8)) == "array(0x05#8)"
+#guard str BV8 (Element.arrayScalar BV8 5) == "array(0x05#8)"
 #guard str BV8 (Element.arange BV8 10) == "array([0x00#8, 0x01#8, 0x02#8, 0x03#8, 0x04#8, 0x05#8, 0x06#8, 0x07#8, 0x08#8, 0x09#8])"
 
 private def arr0 := Element.arange BV8 8
@@ -520,8 +520,8 @@ private def arr1 := Element.arange BV8 12
 #guard (ones (Dtype.float64) $ Shape.mk [2, 2]).nbytes == 2 * 2 * 8
 #guard (ones (Dtype.float64) $ Shape.mk [2, 2]).data.toList.count 1 == 2 * 2
 
-#guard get! ((Element.ofList Element.BV8Native [1, 2, 3]).toTree BV8) == Format.Tree.root [1, 2, 3]
-#guard get! (((Element.ofList Element.BV8Native [0, 1, 2, 3, 4, 5]).reshape! (Shape.mk [2, 3])).toTree BV8) == .node [.root [0, 1, 2], .root [3, 4, 5]]
+#guard get! ((Element.ofList BV8 [1, 2, 3]).toTree BV8) == Format.Tree.root [1, 2, 3]
+#guard get! (((Element.ofList BV8 [0, 1, 2, 3, 4, 5]).reshape! (Shape.mk [2, 3])).toTree BV8) == .node [.root [0, 1, 2], .root [3, 4, 5]]
 
 end Test
 

--- a/TensorLib/Ufunc.lean
+++ b/TensorLib/Ufunc.lean
@@ -56,7 +56,7 @@ private def sum0 (a : Type) [Add a] [Zero a] [Element a] (arr : Tensor) : Err Te
   for index in iter do
     let n : a <- Element.getDimIndex arr index
     acc := Add.add acc n
-  return Element.arrayScalar acc
+  return Element.arrayScalar a acc
 
 -- Sum with a single axis.
 private def sum1 (a : Type) [Add a] [Zero a] [Element a] (arr : Tensor) (axis : Nat) : Err Tensor := do
@@ -147,7 +147,7 @@ private def hasTree1 (a : Type) [Repr a] [BEq a] [Element a] (arr : Tensor) (xs 
 #guard
   let typ := BV8
   let x := Element.arange typ 10
-  let y := Element.arrayScalar (7 : typ)
+  let y := Element.arrayScalar typ 7
   let arr := get! $ add typ x y
   hasTree1 typ arr [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 


### PR DESCRIPTION
The best-effort check we're doing to ensure an index is "compatible" with a shape is wrong headed. For example, if we're indexing a single element from an array, the output shape is [] but we're comparing it to the list of nat indices. Instead of trying to improve the notion, I just removed it and let the indexing itself fail if there's an incorrect index.