### PR TITLE
feat: astype

### DIFF
--- a/TensorLib/Common.lean
+++ b/TensorLib/Common.lean
@@ -727,6 +727,30 @@ def _root_.ByteArray.toUInt32BE! (bs : ByteArray) : UInt32 :=
   (bs.get! 2).toUInt32 <<< 0x28 |||
   (bs.get! 3).toUInt32 <<< 0x20
 
+-- Assumes arr.size == 4
+def Float32.ofLEByteArray! (arr : ByteArray) : Float32 :=
+  Float32.ofBits arr.toUInt32LE!
+
+-- Assumes arr.size == 8
+def Float.ofLEByteArray! (arr : ByteArray) : Float :=
+  Float.ofBits arr.toUInt64LE!
+
+def _root_.Float32.toNat (f : Float32) : Nat := f.toUInt64.toNat
+
+def _root_.Float32.toInt (f : Float32) : Int :=
+  let neg := f <= 0
+  let f := if neg then -f else f
+  let n := Int.ofNat f.toUInt64.toNat
+  if neg then -n else n
+
+def _root_.Float.toNat (f : Float) : Nat := f.toUInt32.toNat
+
+def _root_.Float.toInt (f : Float) : Int :=
+  let neg := f <= 0
+  let f := if neg then -f else f
+  let n := Int.ofNat f.toUInt64.toNat
+  if neg then -n else n
+
 #guard (
   let n : BV64 := 0x3FFAB851EB851EB8
   do

--- a/TensorLib/Ufunc.lean
+++ b/TensorLib/Ufunc.lean
@@ -299,6 +299,15 @@ array([[ 60,  70],
     .node [.node [.root [46, 67], .root [64, 94]]]
   ]
 
+#guard
+  let shape := Shape.mk [2, 3]
+  let t := (arange! Dtype.int8 6).reshape! shape
+  let t := mul! (arrayScalarInt! Dtype.int8 (-1)) t
+  let t1 := Tensor.ofNatList! Dtype.uint8 [0, 0xFF, 0xFE, 0xFD, 0xFC, 0xFB]
+  let t1 := t1.astype! Dtype.int8
+  let t1 := t1.reshape! shape
+  Tensor.arrayEqual t t1
+
 /-! WIP example NKI kernel
 """
 NKI kernel to compute element-wise addition of two input tensors


### PR DESCRIPTION
This rewrites some of the type casting/conversion code and adds NumPy's `astype` method. This is essential for most of the KLR kernels we want to evaluate, as (implicit) casting abounds. There are currently no implicit type conversions; we need to manually call `astype` for now.