### PR TITLE
chore: tweak imports

### DIFF
--- a/TensorLib/Common.lean
+++ b/TensorLib/Common.lean
@@ -6,11 +6,20 @@ Authors: Jean-Baptiste Tristan, Paul Govereau, Sean McLaughlin
 
 import Plausible
 import Std.Tactic.BVDecide
-import TensorLib.Iterator
 
 open Plausible
 
 namespace TensorLib
+
+abbrev Err := Except String
+
+def impossible {a : Type} [h : Inhabited a] (msg : String := "") := @panic a h s!"Invariant violation: {msg}"
+
+def get! [Inhabited a] (x : Err a) : a := match x with
+| .error msg => impossible msg
+| .ok x => x
+
+def natDivCeil (num denom : Nat) : Nat := (num + denom - 1) / denom
 
 private def plausibleDefaultConfig : Plausible.Configuration := {}
 /-

--- a/TensorLib/Iterator.lean
+++ b/TensorLib/Iterator.lean
@@ -4,22 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean-Baptiste Tristan, Paul Govereau, Sean McLaughlin
 -/
 
-import Aesop
+import TensorLib.Common
 
 /-!
 Iterators play a big role in TensorLib.
 -/
 namespace TensorLib
-
-abbrev Err := Except String
-
-def impossible {a : Type} [h : Inhabited a] (msg : String := "") := @panic a h s!"Invariant violation: {msg}"
-
-def get! [Inhabited a] (x : Err a) : a := match x with
-| .error msg => impossible msg
-| .ok x => x
-
-def natDivCeil (num denom : Nat) : Nat := (num + denom - 1) / denom
 
 /-
 An iterator that can be reset to its starting point.


### PR DESCRIPTION
Once we moved Shape to its own file, Common no longer depends on Iterator, so we can have a more straightfoward dependency graph now.