### PR TITLE
chore: make Tensor.toNpy public, remove non-unit strides

### DIFF
--- a/TensorLib/Dtype.lean
+++ b/TensorLib/Dtype.lean
@@ -240,7 +240,7 @@ private def byteArrayToFloat32RoundTrip (dtype : Dtype) (f : Float32) : Bool :=
 NumPy addition overflows and underflows without complaint. We will do the same.
 -/
 def add (dtype : Dtype) (x y : ByteArray) : Err ByteArray :=
-  if dtype.itemsize != x.size || dtype.itemsize != y.size then .error "add: byte size mismatch" else
+  if dtype.itemsize != x.size || dtype.itemsize != y.size then .error s!"add: byte size mismatch: {dtype} {x.size} {y.size}" else
   match dtype with
   | .bool => do
     let x := x.toNat

--- a/TensorLib/Shape.lean
+++ b/TensorLib/Shape.lean
@@ -174,8 +174,6 @@ def intIndexToDimIndex (shape : Shape) (index : List Int) : Err DimIndex := do
 #guard intIndexToDimIndex (Shape.mk [1, 2, 3]) [0, -1, -1] == (.ok [0, 1, 2])
 #guard intIndexToDimIndex (Shape.mk [1, 2, 3]) [0, 1, -2] == (.ok [0, 1, 1])
 
-def iteratorCls : Iterator (Iterator.BEList Iterator.NatIter) (List Nat) := inferInstance
-
 def belist (shape : Shape) : Iterator.BEList Iterator.NatIter :=
   Iterator.BEList.make $ shape.val.map Iterator.NatIter.make
 


### PR DESCRIPTION
We need toNpy for npy-file IO

We had a bug that confused unit and non-unit strides. To keep that
from happening again, we remove the non-unit variant. It's easy
to recover by multiplying by the itemsize.