### PR TITLE
chore: Remove evals

### DIFF
--- a/TensorLib/Common.lean
+++ b/TensorLib/Common.lean
@@ -43,12 +43,15 @@ def dot [Add a][Mul a][Zero a] (x y : List a) : a := (x.zip y).foldl (fun acc (a
 
 section Test
 
-#eval Testable.check (cfg := cfg) (
-  ∀ (x y : Nat),
+/--
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (x y : Nat) :
   let c := natDivCeil x y
   let f := x / y
-  c == f || c == (f + 1)
-)
+  c == f || c == (f + 1) := by
+  plausible (config := cfg)
 
 local instance : SampleableExt (Nat × Nat) :=
   SampleableExt.mkSelfContained do
@@ -56,11 +59,15 @@ local instance : SampleableExt (Nat × Nat) :=
     let n <- SampleableExt.interpSample Nat
     return (x * n, x)
 
-#eval Testable.check (cfg := cfg) (
-  ∀ (xy : Nat × Nat),
+/--
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (xy : Nat × Nat) :
   let (x, y) := xy
-  x % y = 0 → x / y = natDivCeil x y
-)
+  x % y = 0 → x / y = natDivCeil x y := by
+  plausible (config := cfg)
+
 
 end Test
 

--- a/TensorLib/Test.lean
+++ b/TensorLib/Test.lean
@@ -27,10 +27,6 @@ private def testTensorElementBV (dtype : Dtype) : IO Bool := do
   let expected := (Tensor.arange! dtype 20).reshape! (Shape.mk [5, 4])
   return Tensor.arrayEqual expected arr
 
-#eval do
-  let b <- testTensorElementBV Dtype.uint16
-  if !b then throw (IO.userError "fail")
-
 def runAllTests : IO Bool := do
   return (<- testTensorElementBV Dtype.uint16) &&
          (<- testTensorElementBV Dtype.uint32)


### PR DESCRIPTION
One IO #eval seems to be causing problems when used as a library in a different repo. As a matter of tidiness I replaced uses of #eval with #guard/example. I think keeping eval out of our code as a general rule is a good idea, as it tends to just dump output during builds. #guard/#guard_msgs is effective for local testing.