### PR TITLE
Add BEq to Tensor

### DIFF
--- a/TensorLib/Tensor.lean
+++ b/TensorLib/Tensor.lean
@@ -77,7 +77,7 @@ structure Tensor where
   data : ByteArray
   startIndex : Nat := 0 -- Pointer to the first byte of ndarray data. This is implicit in the `data` pointer in numpy.
   unitStrides : Strides := shape.unitStrides
-  deriving Repr, Inhabited
+  deriving Repr, Inhabited, BEq
 
 namespace Tensor
 


### PR DESCRIPTION
This is a tiny patch that adds BEq to Tensor.

https://github.com/leanprover/KLR/pull/111 depends on this patch.