### PR TITLE
chore: Refactor Common.lean I

### DIFF
--- a/TensorLib/Basic.lean
+++ b/TensorLib/Basic.lean
@@ -5,6 +5,7 @@ Authors: Jean-Baptiste Tristan, Paul Govereau, Sean McLaughlin
 -/
 
 import TensorLib.Broadcast
+import TensorLib.Bytes
 import TensorLib.Common
 import TensorLib.Dtype
 import TensorLib.Index

--- a/TensorLib/Bytes.lean
+++ b/TensorLib/Bytes.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jean-Baptiste Tristan, Paul Govereau, Sean McLaughlin
+-/
+
+import Plausible
+import TensorLib.Common
+import Std.Tactic.BVDecide
+
+namespace TensorLib
+
+-- We cast between UIntX and ByteArray without going through BitVec, which is represented
+-- as a Nat at runtime. We'll have tests for these in our ByteArray extension module where we
+-- have conversions back and forth between LE ByteArrays and UIntX.
+def _root_.UInt8.toLEByteArray (n : UInt8) : ByteArray := ByteArray.mk #[n]
+
+
+-- TODO: Prove that (n &&& 0xFF).toUInt8 == n.toUInt8
+section Test
+
+/--
+info: Unable to find a counter-example
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (x : UInt16) :
+  x.toUInt8 == (x &&& 0xFF).toUInt8 ∧
+  (x >>> 8).toUInt8 == (x >>> 8 &&& 0xFF).toUInt8
+  := by plausible
+end Test
+
+def _root_.UInt16.toLEByteArray (n : UInt16) : ByteArray :=
+  let b0 := (n >>> 0).toUInt8
+  let b1 := (n >>> 8).toUInt8
+  ByteArray.mk #[b0, b1]
+
+def _root_.UInt16.toLEByteArray' (n : UInt16) : ByteArray :=
+  let b0 := (n >>> 0).toUInt8
+  let b1 := (n >>> 8).toUInt8
+  ByteArray.mk #[b0, b1]
+
+def _root_.UInt32.toLEByteArray (n : UInt32) : ByteArray :=
+  let b0 := (n >>>  0).toUInt8
+  let b1 := (n >>>  8).toUInt8
+  let b2 := (n >>> 16).toUInt8
+  let b3 := (n >>> 24).toUInt8
+  ByteArray.mk #[b0, b1, b2, b3]
+
+def _root_.UInt64.toLEByteArray (n : UInt64) : ByteArray :=
+  let b0 := (n >>>  0).toUInt8
+  let b1 := (n >>>  8).toUInt8
+  let b2 := (n >>> 16).toUInt8
+  let b3 := (n >>> 24).toUInt8
+  let b4 := (n >>> 32).toUInt8
+  let b5 := (n >>> 40).toUInt8
+  let b6 := (n >>> 48).toUInt8
+  let b7 := (n >>> 56).toUInt8
+  ByteArray.mk #[b0, b1, b2, b3, b4, b5, b6, b7]
+
+def _root_.Int8.toLEByteArray (n : Int8) : ByteArray := n.toUInt8.toLEByteArray
+def _root_.Int16.toLEByteArray (n : Int16) : ByteArray := n.toUInt16.toLEByteArray
+def _root_.Int32.toLEByteArray (n : Int32) : ByteArray := n.toUInt32.toLEByteArray
+def _root_.Int64.toLEByteArray (n : Int64) : ByteArray := n.toUInt64.toLEByteArray
+
+end TensorLib

--- a/TensorLib/Common.lean
+++ b/TensorLib/Common.lean
@@ -384,15 +384,6 @@ example (x : UInt32) :
   x == x' := by
   plausible (config := cfg)
 
-def _root_.UInt8.toLEByteArray (n : UInt8) : ByteArray := bitVecToLEByteArray 8 n.toBitVec
-def _root_.UInt16.toLEByteArray (n : UInt16) : ByteArray := bitVecToLEByteArray 16 n.toBitVec
-def _root_.UInt32.toLEByteArray (n : UInt32) : ByteArray := bitVecToLEByteArray 32 n.toBitVec
-def _root_.UInt64.toLEByteArray (n : UInt64) : ByteArray := bitVecToLEByteArray 64 n.toBitVec
-def _root_.Int8.toLEByteArray (n : Int8) : ByteArray := bitVecToLEByteArray 8 n.toBitVec
-def _root_.Int16.toLEByteArray (n : Int16) : ByteArray := bitVecToLEByteArray 16 n.toBitVec
-def _root_.Int32.toLEByteArray (n : Int32) : ByteArray := bitVecToLEByteArray 32 n.toBitVec
-def _root_.Int64.toLEByteArray (n : Int64) : ByteArray := bitVecToLEByteArray 64 n.toBitVec
-
 private def roundTripUInt32LE (x : UInt32) : Bool :=
   let c := bitVecToLEByteArray 32 x.toBitVec
   let x' := c.toUInt32LE!

--- a/TensorLib/Dtype.lean
+++ b/TensorLib/Dtype.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean-Baptiste Tristan, Paul Govereau, Sean McLaughlin
 -/
 import Plausible
+import TensorLib.Bytes
 import TensorLib.Common
 import TensorLib.Shape
 
@@ -237,15 +238,15 @@ private def canCastFromInt (dtype : Dtype) (n : Int) : Bool :=
 def sizedStrides (dtype : Dtype) (s : Shape) : Strides := List.map (fun x => x * dtype.itemsize) s.unitStrides
 
 def byteArrayOfNatOverflow (dtype : Dtype) (n : Nat) : ByteArray := match dtype with
-| .bool => (BV8.ofNat $ if n == 0 then 0 else 1).toByteArray
-| .uint8 => (BV8.ofNat n).toByteArray
-| .int8 => [(Int8.ofNat n).toUInt8].toByteArray
-| .uint16 => BV16.toByteArray n.toUInt16.toBitVec
-| .int16 => BV16.toByteArray n.toInt16.toBitVec
-| .uint32 => BV32.toByteArray n.toUInt32.toBitVec
-| .int32 => BV32.toByteArray n.toInt32.toBitVec
-| .uint64 => BV64.toByteArray n.toUInt64.toBitVec
-| .int64 => BV64.toByteArray n.toInt64.toBitVec
+| .bool => (if n == 0 then 0 else 1).toUInt8.toLEByteArray
+| .uint8 => n.toUInt8.toLEByteArray
+| .int8 => n.toInt8.toLEByteArray
+| .uint16 => n.toUInt16.toLEByteArray
+| .int16 => n.toInt16.toLEByteArray
+| .uint32 => n.toUInt32.toLEByteArray
+| .int32 => n.toInt32.toLEByteArray
+| .uint64 => n.toUInt64.toLEByteArray
+| .int64 => n.toInt64.toLEByteArray
 | .float32 => n.toFloat32.toLEByteArray
 | .float64 => n.toFloat.toLEByteArray
 


### PR DESCRIPTION
We are refactoring Common to make more utilities useful from KLR and other importing projects. This will come in several steps for ease of code review and comments.

This is step 1: some conversions between IntX/UIntX and ByteArray. The goal is that we can import just the util functions we need for a given set of types, without getting lots of names we don't want.