### PR TITLE
chore: Delete obsolete codeowner file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-* trjohnb@amazon.com
-* govereau@amazon.com
-* seanmcl@amazon.com


### PR DESCRIPTION
The real one is .github/CODEOWNERS